### PR TITLE
Set User to ubuntu for SSH config

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -61,6 +61,7 @@ EOF
 cat <<"EOF" > /home/${ssh_user}/.ssh/config
 Host *
     StrictHostKeyChecking no
+    User ubuntu
 EOF
 chmod 600 /home/${ssh_user}/.ssh/config
 chown ${ssh_user}:${ssh_user} /home/${ssh_user}/.ssh/config


### PR DESCRIPTION
With this change, instead of doing `ssh ubuntu@10.x.x.x` on blackhole, we can just do `ssh 10.x.x.x` for convenience purposes.